### PR TITLE
Remove bean overriding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-## [3.10.12] - 2023-05-04
+## [3.10.14] - 2023-05-11
+### Changed
+- Remove `waggledance.allow-bean-definition-overriding` property to configuration to favor single bean creation.
+
+## [3.10.13] - Not released [YANKED]
+
+## [3.10.12] - 2023-05-04 - [YANKED]
 ### Changed
 - Upgraded `springboot` version to `2.7.11` (was `2.0.4.RELEASE`).
 - Added `spring-boot-starter-validation`.

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/WaggleDance.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/WaggleDance.java
@@ -67,7 +67,6 @@ public class WaggleDance {
       SpringApplication application = new SpringApplicationBuilder(WaggleDance.class)
           .properties("spring.config.location:${server-config:null},${federation-config:null}")
           .properties("server.port:${endpoint.port:18000}")
-          .properties("spring.main.allow-bean-definition-overriding:${waggledance.allow-bean-definition-overriding:true}")
           .registerShutdownHook(true)
           .build();
       exitCode = SpringApplication.exit(registerListeners(application).run(args));


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `main` branch.
* [x] You've successfully built and run the tests locally.
* [x] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
  https://github.com/HotelsDotCom/waggle-dance/blob/main/CONTRIBUTING.md
-->

### :pencil: Description
- Removing bean overriding as a default in favor of keeping a cleaner bean definition.
- Flagged v3.10.12 as Yanked as it was wrongly deployed by mistake from a feature branch.
- Flagged v3.10.13 as Yanked as it was changed by mistake from a maven release action, no deployment to maven central was made. optionally we could revert the commits from the action since it was not actually deployed (?)

### :link: Related Issues