### PR TITLE
add `TServerEventHandler` to clean threadlocal  token in `TokenWrappingHMSHandler`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## [3.11.1] - TBD
+
 ## [3.11.0] - 2023-05-22
 ### Fixed
 - Support kerberos and delegation-token See [#264](https://github.com/ExpediaGroup/waggle-dance/issues/264)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [3.11.1] - TBD
+### Fixed
+- Clean up delegation-token set for Kerberos in thread-local.
 
 ## [3.11.0] - 2023-05-22
 ### Fixed

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/server/MetaStoreProxyServer.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/server/MetaStoreProxyServer.java
@@ -47,10 +47,14 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.thrift.TProcessorFactory;
 import org.apache.thrift.protocol.TBinaryProtocol;
+import org.apache.thrift.protocol.TProtocol;
+import org.apache.thrift.server.ServerContext;
 import org.apache.thrift.server.TServer;
+import org.apache.thrift.server.TServerEventHandler;
 import org.apache.thrift.server.TThreadPoolServer;
 import org.apache.thrift.transport.TFramedTransport;
 import org.apache.thrift.transport.TServerSocket;
+import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
 import org.apache.thrift.transport.TTransportFactory;
 import org.slf4j.Logger;
@@ -188,6 +192,28 @@ public class MetaStoreProxyServer implements ApplicationRunner {
           .requestTimeoutUnit(waggleDanceConfiguration.getThriftServerRequestTimeoutUnit());
 
       tServer = new TThreadPoolServer(args);
+      if (useSASL){
+        TServerEventHandler tServerEventHandler = new TServerEventHandler() {
+          @Override
+          public void preServe() {
+          }
+
+          @Override
+          public ServerContext createContext(TProtocol tProtocol, TProtocol tProtocol1) {
+            return null;
+          }
+
+          @Override
+          public void deleteContext(ServerContext serverContext, TProtocol tProtocol, TProtocol tProtocol1) {
+            TokenWrappingHMSHandler.removeToken();
+          }
+
+          @Override
+          public void processContext(ServerContext serverContext, TTransport tTransport, TTransport tTransport1) {
+          }
+        };
+        tServer.setServerEventHandler(tServerEventHandler);
+      }
       LOG.info("Started the new WaggleDance on port [" + waggleDanceConfiguration.getPort() + "]...");
       LOG.info("Options.minWorkerThreads = " + minWorkerThreads);
       LOG.info("Options.maxWorkerThreads = " + maxWorkerThreads);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
  https://github.com/HotelsDotCom/waggle-dance/blob/main/CONTRIBUTING.md
-->

### :pencil: Description

In this issue https://github.com/ExpediaGroup/waggle-dance/pull/266 , we support kerberos and delegation tokne via TokenWrappingHMSHandler. We found that some time threadload of `TokenWrappingHMSHandler` not be clean when the concurrency is high. So using `TServerEventHandler` to trigger threadlocal remove.

Reference:https://github.com/apache/hive/blob/7bfc54ffc8baf5f3e7de326b750fe9355b11132b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java#L651

test：Manual testing

### :link: Related Issues
no