### PR TITLE
Setting AWSGlueClientFactory log level to WARN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [3.11.2] - 2023-07-04
+### Changed
+- Setting AWSGlueClientFactory log level to `WARN` because it spams this [log](https://github.com/awslabs/aws-glue-data-catalog-client-for-apache-hive-metastore/blob/branch-3.4.0/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/metastore/AWSGlueClientFactory.java#L57) every ~200ms. It could be creating unnecessary Glue clients.
+
 ## [3.11.1] - 2023-05-31
 ### Fixed
 - Clean up delegation-token set for Kerberos in thread-local.

--- a/waggle-dance/src/main/resources/log4j2.xml
+++ b/waggle-dance/src/main/resources/log4j2.xml
@@ -23,6 +23,7 @@
   <Loggers>
     <Logger name="com.hotels.bdp.waggledance" level="debug"/>
     <Logger name="com.hotels.bdp.waggledance.server.invocation-log" level="info"/>
+    <Logger name="com.amazonaws.glue.catalog.metastore.AWSGlueClientFactory" level="warn"/>
     <Root level="info">
       <AppenderRef ref="STDOUT"/>
     </Root>


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
  https://github.com/HotelsDotCom/waggle-dance/blob/main/CONTRIBUTING.md
-->

### :pencil: Description
Setting AWSGlueClientFactory log level to `WARN` because it spams this [log](https://github.com/awslabs/aws-glue-data-catalog-client-for-apache-hive-metastore/blob/branch-3.4.0/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/metastore/AWSGlueClientFactory.java#L57) every ~200ms. It could be creating unnecessary Glue clients.

Why it does create many clients could be some work to do as part of other PR.

### :link: Related Issues