### PR TITLE
fix wrong jetty-all config in pom.xml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [3.11.3] - TBD
 ### Changed
-- Exclude jetty-all from hive-service in pom.xml of core module, because it makes spring start fail and makes `WaggleDanceIntegrationTest` fail.
+- Exclude jetty-all from core module, because it makes spring start fail and makes `WaggleDanceIntegrationTest` fail.
 
 ## [3.11.2] - 2023-07-04
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [3.11.3] - 2023-08-02
+### Changed
+- Exclude jetty-all from hive-service in pom.xml of core module, because it makes spring start fail and makes `WaggleDanceIntegrationTest` fail.
+
 ## [3.11.2] - 2023-07-04
 ### Changed
 - Setting AWSGlueClientFactory log level to `WARN` because it spams this [log](https://github.com/awslabs/aws-glue-data-catalog-client-for-apache-hive-metastore/blob/branch-3.4.0/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/metastore/AWSGlueClientFactory.java#L57) every ~200ms. It could be creating unnecessary Glue clients.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [3.11.3] - 2023-08-02
+## [3.11.3] - TBD
 ### Changed
 - Exclude jetty-all from hive-service in pom.xml of core module, because it makes spring start fail and makes `WaggleDanceIntegrationTest` fail.
 

--- a/waggle-dance-core/pom.xml
+++ b/waggle-dance-core/pom.xml
@@ -127,6 +127,10 @@
           <groupId>log4j</groupId>
           <artifactId>log4j</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jetty.aggregate</groupId>
+          <artifactId>jetty-all</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/waggle-dance-core/pom.xml
+++ b/waggle-dance-core/pom.xml
@@ -179,6 +179,10 @@
           <artifactId>jetty-runner</artifactId>
         </exclusion>
         <exclusion>
+          <groupId>org.eclipse.jetty.aggregate</groupId>
+          <artifactId>jetty-all</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>org.pentaho</groupId>
           <artifactId>pentaho-aggdesigner-algorithm</artifactId>
         </exclusion>       


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
  https://github.com/HotelsDotCom/waggle-dance/blob/main/CONTRIBUTING.md
-->

### :pencil: Description
Exclude jetty-all from hive-service in pom.xml of core module, because it makes spring start fail and makes `WaggleDanceIntegrationTest` fail.


### :link: Related Issues