### PR TITLE
Fix  primary database not filter

### DIFF
--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/mapping/service/impl/StaticDatabaseMappingService.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/mapping/service/impl/StaticDatabaseMappingService.java
@@ -85,6 +85,11 @@ public class StaticDatabaseMappingService implements MappingEventListener {
       QueryMapping queryMapping) {
     this.metaStoreMappingFactory = metaStoreMappingFactory;
     this.queryMapping = queryMapping;
+    mappingsByMetaStoreName = Collections.synchronizedMap(new LinkedHashMap<>());
+    mappingsByDatabaseName = Collections.synchronizedMap(new LinkedHashMap<>());
+    databaseMappingToDatabaseList = new ConcurrentHashMap<>();
+    databaseToTableAllowList = new ConcurrentHashMap<>();
+
     primaryDatabasesCache = CacheBuilder
         .newBuilder()
         .expireAfterAccess(1, TimeUnit.MINUTES)
@@ -94,17 +99,14 @@ public class StaticDatabaseMappingService implements MappingEventListener {
           @Override
           public List<String> load(String key) throws Exception {
             if (primaryDatabaseMapping != null) {
-              return primaryDatabaseMapping.getClient().get_all_databases();
+              return new StaticDatabaseMappingPanopticOperationHandler()
+                  .getPrimaryAllDatabases();
             } else {
               return Lists.newArrayList();
             }
           }
         });
 
-    mappingsByMetaStoreName = Collections.synchronizedMap(new LinkedHashMap<>());
-    mappingsByDatabaseName = Collections.synchronizedMap(new LinkedHashMap<>());
-    databaseMappingToDatabaseList = new ConcurrentHashMap<>();
-    databaseToTableAllowList = new ConcurrentHashMap<>();
     for (AbstractMetaStore federatedMetaStore : initialMetastores) {
       add(federatedMetaStore);
     }
@@ -363,47 +365,64 @@ public class StaticDatabaseMappingService implements MappingEventListener {
 
   @Override
   public PanopticOperationHandler getPanopticOperationHandler() {
-    return new PanopticOperationHandler() {
+    return new StaticDatabaseMappingPanopticOperationHandler();
+  }
 
-      @Override
-      public List<TableMeta> getTableMeta(String db_patterns, String tbl_patterns, List<String> tbl_types) {
+  class StaticDatabaseMappingPanopticOperationHandler extends PanopticOperationHandler {
 
-        BiFunction<TableMeta, DatabaseMapping, Boolean> filter = (tableMeta, mapping) ->
-            databaseAndTableAllowed(tableMeta.getDbName(), tableMeta.getTableName(), mapping);
+    @Override
+    public List<TableMeta> getTableMeta(String db_patterns, String tbl_patterns,
+        List<String> tbl_types) {
 
-        Map<DatabaseMapping, String> mappingsForPattern = new LinkedHashMap<>();
-        for (DatabaseMapping mapping : getAvailableDatabaseMappings()) {
-          mappingsForPattern.put(mapping, db_patterns);
-        }
-        return super.getTableMeta(tbl_patterns, tbl_types, mappingsForPattern, filter);
+      BiFunction<TableMeta, DatabaseMapping, Boolean> filter = (tableMeta, mapping) ->
+          databaseAndTableAllowed(tableMeta.getDbName(), tableMeta.getTableName(), mapping);
+
+      Map<DatabaseMapping, String> mappingsForPattern = new LinkedHashMap<>();
+      for (DatabaseMapping mapping : getAvailableDatabaseMappings()) {
+        mappingsForPattern.put(mapping, db_patterns);
+      }
+      return super.getTableMeta(tbl_patterns, tbl_types, mappingsForPattern, filter);
+    }
+
+    @Override
+    public List<String> getAllDatabases(String pattern) {
+      BiFunction<String, DatabaseMapping, Boolean> filter = getFilter();
+
+      Map<DatabaseMapping, String> mappingsForPattern = new LinkedHashMap<>();
+      for (DatabaseMapping mapping : getAllDatabaseMappings()) {
+        mappingsForPattern.put(mapping, pattern);
       }
 
-      @Override
-      public List<String> getAllDatabases(String pattern) {
-        BiFunction<String, DatabaseMapping, Boolean> filter = (database, mapping) -> mappingsByDatabaseName
-            .containsKey(database);
+      return super.getAllDatabases(mappingsForPattern, filter);
+    }
 
-        BiFunction<String, DatabaseMapping, Boolean> filter1 = (database, mapping) -> filter.apply(database, mapping)
-                && databaseMappingToDatabaseList.get(mapping.getMetastoreMappingName()).contains(database);
+    private BiFunction<String, DatabaseMapping, Boolean> getFilter() {
+      BiFunction<String, DatabaseMapping, Boolean> filter =
+          (database, mapping) -> mappingsByDatabaseName.containsKey(database);
 
-        Map<DatabaseMapping, String> mappingsForPattern = new LinkedHashMap<>();
-        for (DatabaseMapping mapping : getAllDatabaseMappings()) {
-          mappingsForPattern.put(mapping, pattern);
-        }
+      return (database, mapping) -> filter.apply(database, mapping)
+          && databaseMappingToDatabaseList.get(mapping.getMetastoreMappingName())
+          .contains(database);
+    }
 
-        return super.getAllDatabases(mappingsForPattern, filter1);
-      }
+    @Override
+    public List<String> getAllDatabases() {
+      return new ArrayList<>(mappingsByDatabaseName.keySet());
+    }
 
-      @Override
-      public List<String> getAllDatabases() {
-        return new ArrayList<>(mappingsByDatabaseName.keySet());
-      }
+    public List<String> getPrimaryAllDatabases() {
+      BiFunction<String, DatabaseMapping, Boolean> filter = getFilter();
 
-      @Override
-      protected PanopticOperationExecutor getPanopticOperationExecutor() {
-        return new PanopticConcurrentOperationExecutor();
-      }
-    };
+      Map<DatabaseMapping, String> mappingsForPattern = new LinkedHashMap<>();
+      mappingsForPattern.put(primaryDatabaseMapping, "*");
+
+      return super.getAllDatabases(mappingsForPattern, filter);
+    }
+
+    @Override
+    protected PanopticOperationExecutor getPanopticOperationExecutor() {
+      return new PanopticConcurrentOperationExecutor();
+    }
   }
 
   @Override

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/mapping/service/impl/StaticDatabaseMappingService.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/mapping/service/impl/StaticDatabaseMappingService.java
@@ -42,6 +42,7 @@ import org.apache.thrift.TException;
 
 import lombok.extern.log4j.Log4j2;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -410,7 +411,8 @@ public class StaticDatabaseMappingService implements MappingEventListener {
       return new ArrayList<>(mappingsByDatabaseName.keySet());
     }
 
-    public List<String> getPrimaryAllDatabases() {
+    @VisibleForTesting
+    List<String> getPrimaryAllDatabases() {
       BiFunction<String, DatabaseMapping, Boolean> filter = getFilter();
 
       Map<DatabaseMapping, String> mappingsForPattern = new LinkedHashMap<>();

--- a/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/service/impl/StaticDatabaseMappingServiceTest.java
+++ b/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/service/impl/StaticDatabaseMappingServiceTest.java
@@ -64,6 +64,7 @@ import com.hotels.bdp.waggledance.mapping.model.MetaStoreMapping;
 import com.hotels.bdp.waggledance.mapping.model.QueryMapping;
 import com.hotels.bdp.waggledance.mapping.service.MetaStoreMappingFactory;
 import com.hotels.bdp.waggledance.mapping.service.PanopticOperationHandler;
+import com.hotels.bdp.waggledance.mapping.service.impl.StaticDatabaseMappingService.StaticDatabaseMappingPanopticOperationHandler;
 import com.hotels.bdp.waggledance.server.NoPrimaryMetastoreException;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -456,6 +457,25 @@ public class StaticDatabaseMappingServiceTest {
     PanopticOperationHandler handler = service.getPanopticOperationHandler();
     List<String> allDatabases = Lists.newArrayList(PRIMARY_DB, FEDERATED_DB);
     assertThat(handler.getAllDatabases(), is(allDatabases));
+  }
+
+  @Test
+  public void panopticOperationsHandlerGetPrimaryAllDatabases() throws Exception {
+    String pattern = "*";
+    List<String> allPrimaryDatabases =
+        Lists.newArrayList("primary_db1", "primary_db2", "primary_db3");
+    when(primaryDatabaseClient.get_databases(pattern)).thenReturn(allPrimaryDatabases);
+    when(primaryDatabaseClient.get_all_databases()).thenReturn(allPrimaryDatabases);
+
+    primaryMetastore.setMappedDatabases(Lists.newArrayList("primary_db1"));
+
+    service = new StaticDatabaseMappingService(metaStoreMappingFactory,
+        Arrays.asList(primaryMetastore, federatedMetastore), queryMapping);
+
+
+    StaticDatabaseMappingPanopticOperationHandler handler =
+        (StaticDatabaseMappingPanopticOperationHandler) service.getPanopticOperationHandler();
+    assertThat(handler.getPrimaryAllDatabases(), is(Lists.newArrayList("primary_db1")));
   }
 
   @Test

--- a/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/service/impl/StaticDatabaseMappingServiceTest.java
+++ b/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/service/impl/StaticDatabaseMappingServiceTest.java
@@ -479,6 +479,37 @@ public class StaticDatabaseMappingServiceTest {
   }
 
   @Test
+  public void panopticOperationsHandlerStartOkCanFilterPrimaryDatabase() throws Exception {
+    String pattern = "*";
+    List<String> allPrimaryDatabases =
+        Lists.newArrayList("db1", "db2", "db3");
+    when(primaryDatabaseClient.get_databases(pattern)).thenReturn(allPrimaryDatabases);
+    when(primaryDatabaseClient.get_all_databases()).thenReturn(allPrimaryDatabases);
+
+    List<String> allFederatedDatabases =
+        Lists.newArrayList("db2", "db3", "db4");
+    when(federatedDatabaseClient.get_databases(pattern)).thenReturn(allFederatedDatabases);
+    when(federatedDatabaseClient.get_all_databases()).thenReturn(allFederatedDatabases);
+
+    try {
+      primaryMetastore.setMappedDatabases(allPrimaryDatabases);
+      federatedMetastore.setMappedDatabases(allFederatedDatabases);
+      service = new StaticDatabaseMappingService(metaStoreMappingFactory,
+          Arrays.asList(primaryMetastore, federatedMetastore), queryMapping);
+    } catch (WaggleDanceException exception) {
+      primaryMetastore.setMappedDatabases(Lists.newArrayList("db1"));
+      federatedMetastore.setMappedDatabases(Lists.newArrayList("db2", "db3", "db4"));
+
+      service = new StaticDatabaseMappingService(metaStoreMappingFactory,
+          Arrays.asList(primaryMetastore, federatedMetastore), queryMapping);
+
+      return;
+    }
+
+    fail("Shouldn't be here");
+  }
+
+  @Test
   public void panopticOperationsHandlerGetAllDatabasesWithEmptyMappedDatabases() {
     federatedMetastore.setMappedDatabases(Collections.emptyList());
     primaryMetastore.setMappedDatabases(Collections.emptyList());


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
  https://github.com/HotelsDotCom/waggle-dance/blob/main/CONTRIBUTING.md
-->

### :pencil: Description
When database-resolution set manual，primary database also config some database,so to determine whether to add the fed database, it should be necessary to filter out the ones that are not in the primary database.

### :link: Related Issues