### PR TITLE
Support ranger plugin

### DIFF
--- a/HowToRanger.md
+++ b/HowToRanger.md
@@ -1,0 +1,86 @@
+![Bee waggle-dancing on a hive.](logo.png "Federating Hive Meta Stores.")
+
+# Instructions to ranger plugin in Waggle Dance
+
+
+### Process
+
+Apache Ranger is a framework to enable, monitor and manage comprehensive data security across the Hadoop platform. [Apache ranger](https://ranger.apache.org/).
+
+Waggle-dance can implement permission verification based on ranger hive plugin on the metadata side. Permission control is implemented by intercepting the API request to waggle-dance, obtaining the db name and table name, and then sending an authentication request to the ranger. Waggle-Dance ranger-based permission control has the following constraints.
+
+1. The waggle-dance ranger authentication scheme only achieves table-level granularity and cannot achieve column-level granularity.
+2. The waggle-dance ranger authentication scheme does not support ranger’s advanced features, such as `Row level filtering`, `Data masking`, etc.
+3. When a table has `alter`, `update` or `drop` permissions, the table must have `select` permissions
+4. Currently, only the acquisition of `user` and `group` in the Kerberos environment is implemented (other methods need to be expanded in `RangerWrappingHMSHandler`)
+
+
+
+### Configuration
+
+Waggle Dance does not read Hadoop's core-site.xml so the property of ranger plugin should be added to the Hive configuration file `hive-site.xml`:
+
+```
+<property>
+  <name>ranger.plugin.waggle-dance.policy.rest.url</name>
+  <value>http://ranger.url:6080</value>
+</property>
+<property>
+  <name>ranger.plugin.waggle-dance.policy.cache.dir</name>
+  <value>/home/hadoop/cache/path</value>
+</property>
+<property>
+  <name>ranger.plugin.waggle-dance.service.name</name>
+  <value>ranger_service_name</value>
+</property>
+<property>
+  <name>ranger.plugin.waggle-dance.policy.pollIntervalMs</name>
+  <value>180000</value>
+</property>
+
+```
+
+In addition, if use LDAP for account management, the follow property should be add in the `hive-site.xml`.
+
+```
+  <property>
+    <name>hadoop.security.group.mapping</name>
+    <value>org.apache.hadoop.security.LdapGroupsMapping</value>
+  </property>
+  <property>
+    <name>hadoop.security.group.mapping.ldap.url</name>
+    <value>ldap://ldap.url.com:389</value>
+  </property>
+  <property>
+    <name>hadoop.security.group.mapping.ldap.bind.user</name>
+    <value>cn=readonlyuser,dc=x,dc=xxx,dc=xx</value>
+  </property>
+  <property>
+    <name>hadoop.security.group.mapping.ldap.bind.password.file</name>
+    <value>/home/hadoop/path/of/ldap.password</value>
+  </property>
+  <property>
+    <name>hadoop.security.group.mapping.ldap.base</name>
+    <value>dc=xx,dc=xx,dc=x,dc=xx,dc=xx</value>
+  </property>
+  <property>
+    <name>hadoop.security.group.mapping.ldap.search.filter.user</name>
+    <value>(search.filter.user)</value>
+  </property>
+  <property>
+    <name>hadoop.security.group.mapping.ldap.search.filter.group</name>
+    <value>(search.filter.user))</value>
+  </property>
+  <property>
+    <name>hadoop.security.group.mapping.ldap.search.attr.member</name>
+    <value>xxx</value>
+  </property>
+  <property>
+    <name>hadoop.security.group.mapping.ldap.search.attr.group.name</name>
+    <value>xx</value>
+  </property>
+```
+
+### Running
+
+After running, Waggle-dance will pull a ranger policy cache in json format to the `ranger.plugin.waggle-dance.policy.cache.dir` configuration path. And the cache is not updated within the `ranger.plugin.waggle-dance.policy.pollIntervalMs` configured time interval.

--- a/waggle-dance-core/pom.xml
+++ b/waggle-dance-core/pom.xml
@@ -197,6 +197,27 @@
       </exclusions>
     </dependency>
 
+    <!-- Ranger -->
+    <dependency>
+      <groupId>org.apache.ranger</groupId>
+      <artifactId>ranger-hive-plugin</artifactId>
+      <version>1.2.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.hive</groupId>
+          <artifactId>hive-jdbc</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-bundle</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.hive</groupId>
+          <artifactId>hive-common</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
     <!-- Hadoop -->
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/server/MetaStoreProxyServer.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/server/MetaStoreProxyServer.java
@@ -174,6 +174,7 @@ public class MetaStoreProxyServer implements ApplicationRunner {
       HadoopThriftAuthBridge.Server saslServer = null;
 
       if (useSASL) {
+        UserGroupInformation.reset();
         UserGroupInformation.setConfiguration(hiveConf);
         saslServer = SaslHelper.createSaslServer(hiveConf);
       }

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/server/RangerWrappingHMSHandler.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/server/RangerWrappingHMSHandler.java
@@ -1,0 +1,192 @@
+/**
+ * Copyright (C) 2016-2023 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hotels.bdp.waggledance.server;
+
+import java.lang.reflect.*;
+import java.util.Set;
+
+import org.apache.hadoop.hive.metastore.IHMSHandler;
+import org.apache.hadoop.hive.metastore.api.*;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Sets;
+
+import com.hotels.bdp.waggledance.server.security.ranger.RangerAccessControlHandler;
+
+public class RangerWrappingHMSHandler implements InvocationHandler {
+  private final static Logger LOG = LoggerFactory.getLogger(RangerWrappingHMSHandler.class);
+
+  private final IHMSHandler baseHandler;
+  private final RangerAccessControlHandler rangerAccessControlHandler;
+  private String user;
+  private Set<String> groups;
+
+  public static IHMSHandler newProxyInstance(IHMSHandler baseHandler,
+                                             RangerAccessControlHandler rangerAccessControlHandler) {
+    return (IHMSHandler) Proxy.newProxyInstance(RangerWrappingHMSHandler.class.getClassLoader(),
+            new Class[]{IHMSHandler.class}, new RangerWrappingHMSHandler(baseHandler, rangerAccessControlHandler));
+  }
+
+  public RangerWrappingHMSHandler(IHMSHandler baseHandler, RangerAccessControlHandler rangerAccessControlHandler) {
+    this.baseHandler = baseHandler;
+    this.rangerAccessControlHandler = rangerAccessControlHandler;
+  }
+
+  @Override
+  public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+    try {
+      if (TokenWrappingHMSHandler.getToken().isEmpty())
+        return method.invoke(baseHandler, args);
+
+      if (user == null) {
+        String userName = UserGroupInformation.getCurrentUser().getShortUserName();
+        UserGroupInformation ugi = UserGroupInformation.createRemoteUser(userName);
+        user = userName;
+        groups = Sets.newHashSet(ugi.getGroupNames());
+      }
+
+      switch (method.getName()) {
+        // SELECT permissions
+        case "get_table":
+        case "get_partition":
+        case "get_partition_with_auth":
+        case "get_partition_by_name":
+        case "get_partitions":
+        case "get_partitions_with_auth":
+        case "get_partitions_pspec":
+        case "get_partition_names":
+        case "get_partitions_ps":
+        case "get_partitions_ps_with_auth":
+        case "get_partition_names_ps":
+        case "get_partitions_by_filter":
+        case "get_part_specs_by_filter":
+        case "get_partitions_by_names":
+        case "get_table_column_statistics":
+        case "get_partition_column_statistics":
+        case "get_fields_with_environment_context":
+        case "get_num_partitions_by_filter":
+          this.rangerAccessControlHandler.hasSelectPermission(
+                  (String) args[0], (String) args[1], user, groups);
+          break;
+
+        // DROP permissions
+        case "drop_table":
+        case "drop_table_with_environment_context":
+          this.rangerAccessControlHandler.hasDropPermission(
+                  (String) args[0], (String) args[1], user, groups);
+          break;
+
+        // ALTER permissions
+        case "alter_table":
+        case "alter_table_with_environment_context":
+        case "drop_partition":
+        case "drop_partition_with_environment_context":
+        case "drop_partition_by_name":
+        case "drop_partition_by_name_with_environment_context":
+        case "alter_partition":
+        case "alter_partitions":
+        case "alter_partition_with_environment_context":
+        case "rename_partition":
+        case "delete_partition_column_statistics":
+        case "delete_table_column_statistics":
+        case "alter_partitions_with_environment_context":
+        case "alter_table_with_cascade":
+        case "append_partition":
+        case "append_partition_with_environment_context":
+          this.rangerAccessControlHandler.hasAlterPermission(
+                  (String) args[0], (String) args[1], user, groups);
+          break;
+
+        // CREATE permissions
+        case "create_table":
+        case "create_table_with_environment_context":
+        case "create_table_with_constraints":
+          Table tbl = (Table) args[0];
+          this.rangerAccessControlHandler.hasCreatePermission(
+                  tbl.getDbName(), tbl.getTableName(), user, groups);
+          break;
+
+        // other case
+        case "get_partitions_by_expr":
+          PartitionsByExprRequest partExprReq = (PartitionsByExprRequest) args[0];
+          this.rangerAccessControlHandler.hasSelectPermission(
+                  partExprReq.getDbName(), partExprReq.getTblName(), user, groups);
+          break;
+        case "get_table_statistics_req":
+          TableStatsRequest tableStatsRequest = (TableStatsRequest) args[0];
+          this.rangerAccessControlHandler.hasSelectPermission(
+                  tableStatsRequest.getDbName(), tableStatsRequest.getTblName(), user, groups);
+          break;
+        case "get_partitions_statistics_req":
+        case "get_aggr_stats_for":
+          PartitionsStatsRequest partitionsStatsRequest = (PartitionsStatsRequest) args[0];
+          this.rangerAccessControlHandler.hasSelectPermission(
+                  partitionsStatsRequest.getDbName(), partitionsStatsRequest.getTblName(), user, groups);
+          break;
+        case "get_table_req":
+          GetTableRequest getTableRequest = (GetTableRequest) args[0];
+          this.rangerAccessControlHandler.hasSelectPermission(
+                  getTableRequest.getDbName(), getTableRequest.getTblName(), user, groups);
+          break;
+        case "get_partition_values":
+          PartitionValuesRequest partitionValuesRequest = (PartitionValuesRequest) args[0];
+          this.rangerAccessControlHandler.hasSelectPermission(
+                  partitionValuesRequest.getDbName(), partitionValuesRequest.getTblName(), user, groups);
+          break;
+        case "add_partition":
+          Partition partition = (Partition) args[0];
+          this.rangerAccessControlHandler.hasAlterPermission(
+                  partition.getDbName(), partition.getTableName(), user, groups);
+          break;
+        case "add_partitions_req":
+          AddPartitionsRequest addPartitionsRequest = (AddPartitionsRequest) args[0];
+          this.rangerAccessControlHandler.hasAlterPermission(
+                  addPartitionsRequest.getDbName(), addPartitionsRequest.getTblName(), user, groups);
+          break;
+        case "drop_partitions_req":
+          DropPartitionsRequest dropPartitionsRequest = (DropPartitionsRequest) args[0];
+          this.rangerAccessControlHandler.hasAlterPermission(
+                  dropPartitionsRequest.getDbName(), dropPartitionsRequest.getTblName(), user, groups);
+          break;
+        case "update_table_column_statistics":
+        case "update_partition_column_statistics":
+          ColumnStatistics columnStatistics = (ColumnStatistics) args[0];
+          this.rangerAccessControlHandler.hasAlterPermission(
+                  columnStatistics.getStatsDesc().getDbName(),
+                  columnStatistics.getStatsDesc().getTableName(), user, groups);
+          break;
+        // special case, pass it
+        case "add_partitions":
+        case "add_partitions_pspec":
+        case "drop_constraint":
+        case "partition_name_has_valid_characters":
+        case "set_aggr_stats_for":
+
+        default:
+          break;
+      }
+      return method.invoke(baseHandler, args);
+    } catch (InvocationTargetException e) {
+      throw e.getCause();
+    } catch (UndeclaredThrowableException e) {
+      // Need to unwrap this, so callers get the correct exception thrown by the handler.
+      throw e.getCause();
+    }
+  }
+
+}

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/server/TSetIpAddressProcessorFactory.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/server/TSetIpAddressProcessorFactory.java
@@ -31,6 +31,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import com.hotels.bdp.waggledance.server.security.ranger.RangerAccessControlFactory;
+
 @Component
 class TSetIpAddressProcessorFactory extends TProcessorFactory {
 
@@ -61,7 +63,11 @@ class TSetIpAddressProcessorFactory extends TProcessorFactory {
 
       boolean useSASL = hiveConf.getBoolVar(HiveConf.ConfVars.METASTORE_USE_THRIFT_SASL);
       if (useSASL) {
-        IHMSHandler tokenHandler = TokenWrappingHMSHandler.newProxyInstance(baseHandler, useSASL);
+
+        IHMSHandler rangerHandler = RangerWrappingHMSHandler.newProxyInstance(baseHandler,
+                RangerAccessControlFactory.getInstance(hiveConf));
+        IHMSHandler tokenHandler = TokenWrappingHMSHandler.newProxyInstance(rangerHandler, useSASL);
+
         IHMSHandler handler = newRetryingHMSHandler(ExceptionWrappingHMSHandler.newProxyInstance(tokenHandler), hiveConf,
                 false);
         return new TSetIpAddressProcessor<>(handler);

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/server/security/ranger/AccessRequest.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/server/security/ranger/AccessRequest.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) 2016-2023 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hotels.bdp.waggledance.server.security.ranger;
+
+import java.util.Date;
+import java.util.Set;
+
+import org.apache.ranger.plugin.policyengine.RangerAccessRequestImpl;
+import org.apache.ranger.plugin.policyengine.RangerAccessResource;
+
+public class AccessRequest extends RangerAccessRequestImpl {
+  private AccessType accessType;
+  private RangerAccessResource resource;
+
+  public AccessRequest(RangerAccessResource resource, AccessType accessType, String user, Set<String> groups) {
+    this();
+    this.resource = resource;
+    this.accessType = accessType;
+    this.setResource(resource);
+    this.setAccessType(accessType.name().toLowerCase());
+    this.setAction(accessType.toString());
+    this.setUser(user);
+    this.setUserGroups(groups);
+    this.setAccessTime(new Date());
+  }
+
+  private AccessRequest() {
+    super();
+  }
+
+}

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/server/security/ranger/AccessType.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/server/security/ranger/AccessType.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (C) 2016-2023 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hotels.bdp.waggledance.server.security.ranger;
+
+public enum AccessType {
+  NONE, CREATE, ALTER, DROP, INDEX, LOCK, SELECT, UPDATE, INSPECT, USE, ALL, ADMIN
+
+}

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/server/security/ranger/DefaultRangerAccessControlHandler.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/server/security/ranger/DefaultRangerAccessControlHandler.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (C) 2016-2023 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hotels.bdp.waggledance.server.security.ranger;
+
+import java.util.Set;
+
+public class DefaultRangerAccessControlHandler implements RangerAccessControlHandler {
+
+  @Override
+  public boolean hasUpdatePermission(String databaseName, String tableName, String user, Set<String> groups) {
+    return true;
+  }
+
+  @Override
+  public boolean hasCreatePermission(String databaseName, String tableName, String user, Set<String> groups) {
+    return true;
+  }
+
+  @Override
+  public boolean hasSelectPermission(String databaseName, String tableName, String user, Set<String> groups) {
+    return true;
+  }
+
+  @Override
+  public boolean hasDropPermission(String databaseName, String tableName, String user, Set<String> groups) {
+    return true;
+  }
+
+  @Override
+  public boolean hasAlterPermission(String databaseName, String tableName, String user, Set<String> groups) {
+    return true;
+  }
+
+}

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/server/security/ranger/RangerAccessControlFactory.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/server/security/ranger/RangerAccessControlFactory.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2016-2023 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hotels.bdp.waggledance.server.security.ranger;
+
+import static com.hotels.bdp.waggledance.server.security.ranger.WaggleDanceRangerUtil.RANGER_REST_URL;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+
+public class RangerAccessControlFactory {
+
+  private static RangerAccessControlHandler instance;
+
+  public static RangerAccessControlHandler getInstance(HiveConf conf) {
+    if (instance == null) {
+      synchronized (RangerAccessControlFactory.class) {
+        if (instance == null) {
+          String rangerRestUrl = conf.get(RANGER_REST_URL);
+          if (rangerRestUrl == null || rangerRestUrl.isEmpty())
+            instance = new DefaultRangerAccessControlHandler();
+          else
+            instance = new RangerAccessControlHandlerImpl(conf);
+        }
+      }
+    }
+    return instance;
+  }
+
+  private RangerAccessControlFactory() {}
+
+}

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/server/security/ranger/RangerAccessControlHandler.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/server/security/ranger/RangerAccessControlHandler.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) 2016-2023 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hotels.bdp.waggledance.server.security.ranger;
+
+
+import java.util.Set;
+
+public interface RangerAccessControlHandler {
+
+  boolean hasUpdatePermission(String databaseName, String tableName, String user, Set<String> groups);
+
+  boolean hasCreatePermission(String databaseName, String tableName, String user, Set<String> groups);
+
+  boolean hasSelectPermission(String databaseName, String tableName, String user, Set<String> groups);
+
+  boolean hasDropPermission(String databaseName, String tableName, String user, Set<String> groups);
+
+  boolean hasAlterPermission(String databaseName, String tableName, String user, Set<String> groups);
+
+}

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/server/security/ranger/RangerAccessControlHandlerImpl.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/server/security/ranger/RangerAccessControlHandlerImpl.java
@@ -1,0 +1,168 @@
+/**
+ * Copyright (C) 2016-2023 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hotels.bdp.waggledance.server.security.ranger;
+
+import static com.hotels.bdp.waggledance.server.security.ranger.WaggleDanceRangerUtil.*;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.ranger.authorization.hadoop.config.RangerConfiguration;
+import org.apache.ranger.plugin.policyengine.RangerAccessResult;
+import org.apache.ranger.plugin.service.RangerBasePlugin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+
+import com.hotels.bdp.waggledance.server.security.NotAllowedException;
+
+public class RangerAccessControlHandlerImpl implements RangerAccessControlHandler {
+  private static final Logger LOG = LoggerFactory.getLogger(RangerAccessControlHandlerImpl.class);
+
+  private static Cache<String, Boolean> accessCache;
+  private final RangerSQLPlugin plugin;
+
+  public RangerAccessControlHandlerImpl(HiveConf conf) {
+    String adminUri = conf.get(RANGER_REST_URL);
+    URI adminURI = URI.create(adminUri);
+
+    String cacheDir = conf.get(CACHE_DIR);
+    String rangerService = conf.get(RANGER_SERVICE_NAME);
+    LOG.info(String.format("Init ranger plugun , ranger admin uri : %s ,cache dir %s ,ranger service %s"
+            , adminUri, cacheDir, rangerService));
+
+    RangerConfiguration rangerConfiguration = RangerConfiguration.getInstance();
+    rangerConfiguration.addResource(conf);
+
+    rangerConfiguration.set(RANGER_REST_URL, adminURI.toString());
+    if (cacheDir != null) {
+      LOG.info("Using Ranger policy cache dir `{}`", cacheDir);
+      Path path = Paths.get(cacheDir);
+      if (Files.notExists(path)) {
+        try {
+          Files.createDirectory(path);
+          rangerConfiguration.set(CACHE_DIR, cacheDir);
+        } catch (IOException ex) {
+          LOG.warn("Failed to ensure Ranger cache dir `{}`. Run without caching", path, ex);
+        }
+      } else {
+        rangerConfiguration.set(CACHE_DIR, cacheDir);
+      }
+    } else {
+      LOG.warn("Running GDC SQL Ranger Authorizer without policy caching");
+    }
+
+    if (rangerService == null)
+      throw new IllegalArgumentException(String.format(
+              "Ranger policy service configuration was not found"));
+    LOG.info("Using Ranger policy service `{}`, Admin=`{}`",
+            rangerService, "adminUri");
+    rangerConfiguration.set(RANGER_SERVICE_NAME, rangerService);
+    rangerConfiguration.set(
+            RANGER_SOURCE_IMPL,
+            "org.apache.ranger.admin.client.RangerAdminRESTClient");
+    rangerConfiguration.set(RANGER_POLICY_POLLINTERVAL,
+            conf.get(RANGER_POLICY_POLLINTERVAL, "180000"));
+    UserGroupInformation.setConfiguration(rangerConfiguration);
+
+    if (accessCache == null) {
+      //TODO: make parameters configurable
+      accessCache = CacheBuilder.newBuilder()
+              .concurrencyLevel(5)
+              .initialCapacity(100)
+              .maximumSize(3000)
+              .expireAfterWrite(600, TimeUnit.SECONDS)
+              .removalListener(notification -> {
+                LOG.info(String.format("key %s value %s be removed, because %s", notification.getKey(), notification.getValue(),
+                        notification.getCause()));
+              })
+              .build();
+    }
+
+    this.plugin = new RangerSQLPlugin(SERVICE_TYPE);
+    this.plugin.init();
+  }
+
+  private boolean getPermissionWithCache(String databaseName, String tableName, String user, AccessType type) {
+    String typeString = String.format("%s_%s_%s_%s", databaseName, tableName, user, type.toString());
+    return accessCache.getIfPresent(typeString) != null;
+  }
+
+  private void addPermission2Cache(String databaseName, String tableName, String user, AccessType type) {
+    String typeString = String.format("%s_%s_%s_%s", databaseName, tableName, user, type.toString());
+    accessCache.put(typeString, true);
+  }
+
+  @Override
+  public boolean hasUpdatePermission(String databaseName, String tableName, String user, Set<String> groups) {
+    return checkTablePermissionInternal(databaseName, tableName, user, groups, AccessType.UPDATE);
+  }
+
+  @Override
+  public boolean hasCreatePermission(String databaseName, String tableName, String user, Set<String> groups) {
+    return checkTablePermissionInternal(databaseName, tableName, user, groups, AccessType.CREATE);
+  }
+
+  @Override
+  public boolean hasSelectPermission(String databaseName, String tableName, String user, Set<String> groups) {
+    return checkTablePermissionInternal(databaseName, tableName, user, groups, AccessType.SELECT);
+  }
+
+  @Override
+  public boolean hasDropPermission(String databaseName, String tableName, String user, Set<String> groups) {
+    return checkTablePermissionInternal(databaseName, tableName, user, groups, AccessType.DROP);
+  }
+
+  @Override
+  public boolean hasAlterPermission(String databaseName, String tableName, String user, Set<String> groups) {
+    return checkTablePermissionInternal(databaseName, tableName, user, groups, AccessType.ALTER);
+  }
+
+  private boolean checkTablePermissionInternal(String databaseName, String tableName,
+                                               String user, Set<String> groups, AccessType accessType) {
+    if (getPermissionWithCache(databaseName, tableName, user, accessType))
+      return true;
+    Resource resource = new Resource(Resource.Type.TABLE, databaseName, tableName);
+    AccessRequest accRequest = new AccessRequest(resource, accessType, user, groups);
+    RangerAccessResult result = plugin.isAccessAllowed(accRequest);
+    if (result != null || !result.getIsAllowed()) {
+      throw new NotAllowedException(String.format(
+              "ranger authorization failed, User %s, User group %s, db %s table %s, accessType %s",
+              accRequest.getUser(), accRequest.getUserGroups(),
+              accRequest.getResource().getValue("database"),
+              accRequest.getResource().getValue("table"), accRequest.getAccessType()
+      ));
+    }
+    addPermission2Cache(databaseName, tableName, user, AccessType.ALTER);
+    return true;
+  }
+
+  static class RangerSQLPlugin extends RangerBasePlugin {
+    public RangerSQLPlugin(String service) {
+      super(service, service);
+    }
+  }
+
+}

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/server/security/ranger/Resource.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/server/security/ranger/Resource.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (C) 2016-2023 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hotels.bdp.waggledance.server.security.ranger;
+
+import static java.lang.String.format;
+
+import org.apache.ranger.plugin.policyengine.RangerAccessResourceImpl;
+
+class Resource extends RangerAccessResourceImpl {
+  private static final String KEY_DATABASE = "database";
+  private static final String KEY_TABLE = "table";
+  private static final String KEY_UDF = "udf";
+  private static final String KEY_COLUMN = "column";
+
+  private Type type = null;
+
+  Resource(Type objectType, String database, String tableOrUdf) {
+    this(objectType, database, tableOrUdf, null);
+  }
+
+  Resource(Type objectType, String database, String tableOrUdf, String column) {
+    this.type = objectType;
+
+    switch (objectType) {
+      case DATABASE:
+        setValue(KEY_DATABASE, database);
+        break;
+
+      case FUNCTION:
+        setValue(KEY_DATABASE, database);
+        setValue(KEY_UDF, tableOrUdf);
+        break;
+
+      case TABLE:
+      case VIEW:
+      case INDEX:
+      case PARTITION:
+        setValue(KEY_DATABASE, database);
+        setValue(KEY_TABLE, tableOrUdf);
+        break;
+
+      case NONE:
+      case URI:
+      default:
+        break;
+    }
+  }
+
+  public Type getType() {
+    return type;
+  }
+
+  public String getDatabase() {
+    return (String) getValue(KEY_DATABASE);
+  }
+
+  public String getTable() {
+    return (String) getValue(KEY_TABLE);
+  }
+
+  public String getUdf() {
+    return (String) getValue(KEY_UDF);
+  }
+
+  public String getColumn() {
+    return (String) getValue(KEY_COLUMN);
+  }
+
+  public String getLoggingMessage() {
+    switch (type) {
+      case DATABASE:
+        return format("database `%s`", getDatabase());
+      case FUNCTION:
+        return format("function `%s.%s`", getDatabase(), getUdf());
+      case TABLE:
+      case VIEW:
+      case INDEX:
+      case PARTITION:
+        return format("%s `%s.%s`", type.name().toLowerCase(), getDatabase(), getTable());
+      case COLUMN:
+        return format("column `%s` of `%s.%s`", getColumn(), getDatabase(), getTable());
+      case NONE:
+      case URI:
+      default:
+        throw new IllegalArgumentException(format("Unsupported resource type `%s`", type.name()));
+    }
+  }
+
+  public enum Type {
+    NONE, DATABASE, TABLE, VIEW, PARTITION, INDEX, COLUMN, FUNCTION, URI
+  }
+
+}

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/server/security/ranger/WaggleDanceRangerUtil.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/server/security/ranger/WaggleDanceRangerUtil.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (C) 2016-2023 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hotels.bdp.waggledance.server.security.ranger;
+
+public class WaggleDanceRangerUtil {
+
+  // Prefix
+  public static final String SERVICE_TYPE = "waggle-dance";
+  public static final String PROPERTY_PREFIX = "ranger.plugin." + SERVICE_TYPE;
+
+  // Ranger properties
+  public static final String RANGER_REST_URL = PROPERTY_PREFIX + ".policy.rest.url";
+  public static final String CACHE_DIR = PROPERTY_PREFIX + ".policy.cache.dir";
+  public static final String RANGER_SERVICE_NAME = PROPERTY_PREFIX + ".service.name";
+  public static final String RANGER_SOURCE_IMPL = PROPERTY_PREFIX + ".policy.source.impl";
+  public static final String RANGER_POLICY_POLLINTERVAL = PROPERTY_PREFIX + ".policy.pollIntervalMs";
+
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
  https://github.com/HotelsDotCom/waggle-dance/blob/main/CONTRIBUTING.md
-->

### :pencil: Description

### overview

Apache Ranger is a framework to enable, monitor and manage comprehensive data security across the Hadoop platform. [Apache ranger](https://ranger.apache.org/).


There is currently a lack of metadata authentication solutions in the industry. Although Apache ranger provides hiveserver authentication solutions, this has limited support for hive-cli, spark-submit and other scenarios. The solution we designed is to reuse the ranger hiveserver plugin in waggle-dance to achieve permission control on the metadata side.

This solution has the following limitations:

1. The waggle-dance ranger authentication scheme only achieves table-level granularity and cannot achieve column-level granularity.
2. The waggle-dance ranger authentication scheme does not support ranger’s advanced features, such as `Row level filtering`, `Data masking`, etc., and only implements authentication.
3. If you have alter, update or drop permissions on a table, you must have select permissions
4. Currently, only the acquisition of `user` and `group` in the Kerberos environment is implemented (other methods need to be expanded in `RangerWrappingHMSHandler`)

### implement

We implement the `RangerWrappingHMSHandler` like `TokenWrappingHMSHandler`. Intercept the metastore API request and obtain the db and table fields, and then perform ranger authentication.

Considering that a hive statement may execute multiple API requests (select statements will execute multiple get_table requests), we designed a gauva cache to cache a copy of permission information in memory.


### :link: Related Issues