### PR TITLE
Remove the wrong cursor version from dependent hadoop common

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,10 @@
             <groupId>javax.servlet</groupId>
             <artifactId>*</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
  https://github.com/HotelsDotCom/waggle-dance/blob/main/CONTRIBUTING.md
-->

### :pencil: Description
hadoop 3.3.6 --> curator 5.2.x which is incompatible with decalared 2.13.0. Sometimes errors may occur when start wd.



### :link: Related Issues