### PR TITLE
Add hive hook configuration parameters for each hms

### DIFF
--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/mapping/model/MetaStoreMappingFactoryImpl.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/mapping/model/MetaStoreMappingFactoryImpl.java
@@ -108,6 +108,12 @@ public class MetaStoreMappingFactoryImpl implements MetaStoreMappingFactory {
         conf.set(property.getKey(), property.getValue());
       }
     }
+    Map<String, String> metaConfigurationProperties = metaStore.getConfigurationProperties();
+    if (metaConfigurationProperties != null) {
+      for (Map.Entry<String, String> property : metaConfigurationProperties.entrySet()) {
+        conf.set(property.getKey(), property.getValue());
+      }
+    }
     conf.set(HiveConf.ConfVars.METASTORE_FILTER_HOOK.varname, metaStoreFilterHook);
     try {
       Class<? extends MetaStoreFilterHook> filterHookClass = conf

--- a/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/model/MetaStoreMappingFactoryImplTest.java
+++ b/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/model/MetaStoreMappingFactoryImplTest.java
@@ -143,13 +143,29 @@ public class MetaStoreMappingFactoryImplTest {
   public void loadMetastoreFilterHookFromConfig() {
     AbstractMetaStore federatedMetaStore = newFederatedInstance("fed1", thrift.getThriftConnectionUri());
     federatedMetaStore.setHiveMetastoreFilterHook(PrefixingMetastoreFilter.class.getName());
+    MetaStoreMapping mapping = factory.newInstance(federatedMetaStore);
+    assertThat(mapping, is(notNullValue()));
+    assertThat(mapping.getMetastoreFilter(), instanceOf(PrefixingMetastoreFilter.class));
+  }
+
+  @Test
+  public void loadDefaultMetastoreFilterHook() {
+    AbstractMetaStore federatedMetaStore = newFederatedInstance("fed1", thrift.getThriftConnectionUri());
+    MetaStoreMapping mapping = factory.newInstance(federatedMetaStore);
+    assertThat(mapping, is(notNullValue()));
+    assertThat(mapping.getMetastoreFilter(), instanceOf(DefaultMetaStoreFilterHookImpl.class));
+  }
+
+  @Test
+  public void loadMetastoreFilterHookWithCustomConfig() {
+    AbstractMetaStore federatedMetaStore = newFederatedInstance("fed1", thrift.getThriftConnectionUri());
+    federatedMetaStore.setHiveMetastoreFilterHook(PrefixingMetastoreFilter.class.getName());
     Map<String,String> metaStoreConfigurationProperties = new HashMap<>();
     metaStoreConfigurationProperties.put(PrefixingMetastoreFilter.PREFIX_KEY,"prefix-test-");
     federatedMetaStore.setConfigurationProperties(metaStoreConfigurationProperties);
 
     MetaStoreMapping mapping = factory.newInstance(federatedMetaStore);
     assertThat(mapping, is(notNullValue()));
-
     MetaStoreFilterHook filterHook = mapping.getMetastoreFilter();
     assertThat(filterHook, instanceOf(PrefixingMetastoreFilter.class));
 
@@ -164,13 +180,5 @@ public class MetaStoreMappingFactoryImplTest {
       assertThat(filterHook.filterTable(table).getSd().getLocation(), equalTo("prefix-test-" + oldLocation ) );
     }catch (Exception e){
     }
-  }
-
-  @Test
-  public void loadDefaultMetastoreFilterHook() {
-    AbstractMetaStore federatedMetaStore = newFederatedInstance("fed1", thrift.getThriftConnectionUri());
-    MetaStoreMapping mapping = factory.newInstance(federatedMetaStore);
-    assertThat(mapping, is(notNullValue()));
-    assertThat(mapping.getMetastoreFilter(), instanceOf(DefaultMetaStoreFilterHookImpl.class));
   }
 }

--- a/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/model/MetaStoreMappingFactoryImplTest.java
+++ b/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/model/MetaStoreMappingFactoryImplTest.java
@@ -140,11 +140,6 @@ public class MetaStoreMappingFactoryImplTest {
   }
 
   @Test
-  public void loadMetastoreFilterHook(){
-
-  }
-
-  @Test
   public void loadMetastoreFilterHookFromConfig() {
     AbstractMetaStore federatedMetaStore = newFederatedInstance("fed1", thrift.getThriftConnectionUri());
     federatedMetaStore.setHiveMetastoreFilterHook(PrefixingMetastoreFilter.class.getName());

--- a/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/model/MetaStoreMappingFactoryImplTest.java
+++ b/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/model/MetaStoreMappingFactoryImplTest.java
@@ -15,7 +15,10 @@
  */
 package com.hotels.bdp.waggledance.mapping.model;
 
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
@@ -157,7 +160,7 @@ public class MetaStoreMappingFactoryImplTest {
   }
 
   @Test
-  public void loadMetastoreFilterHookWithCustomConfig() {
+  public void loadMetastoreFilterHookWithCustomConfig() throws Exception{
     AbstractMetaStore federatedMetaStore = newFederatedInstance("fed1", thrift.getThriftConnectionUri());
     federatedMetaStore.setHiveMetastoreFilterHook(PrefixingMetastoreFilter.class.getName());
     Map<String,String> metaStoreConfigurationProperties = new HashMap<>();
@@ -170,7 +173,6 @@ public class MetaStoreMappingFactoryImplTest {
     assertThat(filterHook, instanceOf(PrefixingMetastoreFilter.class));
 
     Table table = new Table();
-    try {
       StorageDescriptor sd = new StorageDescriptor();
       File localWarehouseUri = temporaryFolder.newFolder("local-warehouse");
       sd.setLocation(new File(localWarehouseUri,"local_database/local_table").toURI().toString());
@@ -178,7 +180,5 @@ public class MetaStoreMappingFactoryImplTest {
 
       String oldLocation=sd.getLocation();
       assertThat(filterHook.filterTable(table).getSd().getLocation(), equalTo("prefix-test-" + oldLocation ) );
-    }catch (Exception e){
-    }
   }
 }

--- a/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/model/MetaStoreMappingFactoryImplTest.java
+++ b/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/model/MetaStoreMappingFactoryImplTest.java
@@ -26,7 +26,6 @@ import static org.mockito.Mockito.when;
 
 import static com.hotels.bdp.waggledance.api.model.AbstractMetaStore.newFederatedInstance;
 
-import java.io.File;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -39,7 +38,6 @@ import org.apache.thrift.TException;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -72,7 +70,6 @@ public class MetaStoreMappingFactoryImplTest {
       new WaggleDanceConfiguration(), new SplitTrafficMetastoreClientFactory());
 
   private MetaStoreMappingFactoryImpl factory;
-  public @Rule TemporaryFolder temporaryFolder = new TemporaryFolder();
 
   @Before
   public void init() {
@@ -173,12 +170,11 @@ public class MetaStoreMappingFactoryImplTest {
     assertThat(filterHook, instanceOf(PrefixingMetastoreFilter.class));
 
     Table table = new Table();
-      StorageDescriptor sd = new StorageDescriptor();
-      File localWarehouseUri = temporaryFolder.newFolder("local-warehouse");
-      sd.setLocation(new File(localWarehouseUri,"local_database/local_table").toURI().toString());
-      table.setSd(sd);
+    StorageDescriptor sd = new StorageDescriptor();
+    sd.setLocation("file:///tmp/local_database/local_table");
+    table.setSd(sd);
 
-      String oldLocation=sd.getLocation();
-      assertThat(filterHook.filterTable(table).getSd().getLocation(), equalTo("prefix-test-" + oldLocation ) );
+    String oldLocation=sd.getLocation();
+    assertThat(filterHook.filterTable(table).getSd().getLocation(), equalTo("prefix-test-" + oldLocation ) );
   }
 }

--- a/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/model/PrefixingMetastoreFilter.java
+++ b/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/model/PrefixingMetastoreFilter.java
@@ -33,7 +33,7 @@ import org.apache.hadoop.hive.metastore.api.TableMeta;
  * */
 public class PrefixingMetastoreFilter implements MetaStoreFilterHook {
 
-  public static final String PREFIX_KEY = "hive.metastore.hooks.prefix";
+  public static final String PREFIX_KEY = "waggledance.hook.prefix";
   public static final String PREFIX_DEFAULT = "prefix-";
   private final String prefix;
 

--- a/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/model/PrefixingMetastoreFilter.java
+++ b/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/model/PrefixingMetastoreFilter.java
@@ -33,9 +33,12 @@ import org.apache.hadoop.hive.metastore.api.TableMeta;
  * */
 public class PrefixingMetastoreFilter implements MetaStoreFilterHook {
 
-  public static final String PREFIX = "prefix-";
+  public static final String PREFIX_KEY = "hive.metastore.hooks.prefix";
+  public static final String PREFIX_DEFAULT = "prefix-";
+  private final String prefix;
 
   public PrefixingMetastoreFilter(HiveConf conf) {
+    prefix = conf.get(PREFIX_KEY,PREFIX_DEFAULT);
   }
 
   @Override
@@ -140,7 +143,7 @@ public class PrefixingMetastoreFilter implements MetaStoreFilterHook {
 
   private void setLocationPrefix(StorageDescriptor sd) {
     String location = sd.getLocation();
-    sd.setLocation(PREFIX + location);
+    sd.setLocation(prefix + location);
   }
 
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
  https://github.com/HotelsDotCom/waggle-dance/blob/main/CONTRIBUTING.md
-->

### :pencil: Description
When configuring hive hooks in waggle-dance-server.yml, it will take effect on all primary hms or federate hms. It does not support specifying hive hooks for individual hms.
Now it is supported to add hive hook configuration for a single primary hms or federate hms in waggle-dance-federation.yml without affecting each other.

### :link: Related Issues
#320 