### PR TITLE
Resolved the issue where the custom database prefix was lost after th…

### DIFF
--- a/waggle-dance-api/src/main/java/com/hotels/bdp/waggledance/api/model/AbstractMetaStore.java
+++ b/waggle-dance-api/src/main/java/com/hotels/bdp/waggledance/api/model/AbstractMetaStore.java
@@ -80,6 +80,20 @@ public abstract class AbstractMetaStore {
     this.writableDatabaseWhitelist = writableDatabaseWhitelist;
   }
 
+  public AbstractMetaStore(
+          String name,
+          String remoteMetaStoreUris,
+          String databasePrefix,
+          AccessControlType accessControlType,
+          List<String> writableDatabaseWhitelist) {
+    this.name = name;
+    this.remoteMetaStoreUris = remoteMetaStoreUris;
+    this.databasePrefix = databasePrefix;
+    this.accessControlType = accessControlType;
+    this.writableDatabaseWhitelist = writableDatabaseWhitelist;
+  }
+
+
   public static FederatedMetaStore newFederatedInstance(String name, String remoteMetaStoreUris) {
     return new FederatedMetaStore(name, remoteMetaStoreUris);
   }
@@ -93,6 +107,14 @@ public abstract class AbstractMetaStore {
 
   public static PrimaryMetaStore newPrimaryInstance(String name, String remoteMetaStoreUris) {
     return new PrimaryMetaStore(name, remoteMetaStoreUris, AccessControlType.READ_ONLY);
+  }
+
+  public static PrimaryMetaStore newPrimaryInstance(
+          String name,
+          String remoteMetaStoreUris,
+          String databasePrefix,
+          AccessControlType accessControlType) {
+    return new PrimaryMetaStore(name, remoteMetaStoreUris, databasePrefix, accessControlType);
   }
 
   public String getDatabasePrefix() {

--- a/waggle-dance-api/src/main/java/com/hotels/bdp/waggledance/api/model/PrimaryMetaStore.java
+++ b/waggle-dance-api/src/main/java/com/hotels/bdp/waggledance/api/model/PrimaryMetaStore.java
@@ -43,6 +43,24 @@ public class PrimaryMetaStore extends AbstractMetaStore {
     super(name, remoteMetaStoreUris, accessControlType, writableDatabaseWhitelist);
   }
 
+  public PrimaryMetaStore(
+          String name,
+          String remoteMetaStoreUris,
+          String databasePrefix,
+          AccessControlType accessControlType,
+          String... writableDatabaseWhitelist) {
+    this(name, remoteMetaStoreUris, databasePrefix, accessControlType, Arrays.asList(writableDatabaseWhitelist));
+  }
+
+  public PrimaryMetaStore(
+          String name,
+          String remoteMetaStoreUris,
+          String databasePrefix,
+          AccessControlType accessControlType,
+          List<String> writableDatabaseWhitelist) {
+    super(name, remoteMetaStoreUris, databasePrefix, accessControlType, writableDatabaseWhitelist);
+  }
+
   @Override
   public FederationType getFederationType() {
     return FederationType.PRIMARY;

--- a/waggle-dance-api/src/test/java/com/hotels/bdp/waggledance/api/model/AbstractMetaStoreTest.java
+++ b/waggle-dance-api/src/test/java/com/hotels/bdp/waggledance/api/model/AbstractMetaStoreTest.java
@@ -155,6 +155,18 @@ public abstract class AbstractMetaStoreTest<T extends AbstractMetaStore> {
   }
 
   @Test
+  public void newPrimaryPrefixInstance() {
+    AccessControlType access = AccessControlType.READ_AND_WRITE_AND_CREATE;
+    String databasePrefix = "primary";
+    PrimaryMetaStore primaryMetaStore = AbstractMetaStore.newPrimaryInstance(name, remoteMetaStoreUri, databasePrefix, access);
+    assertThat(primaryMetaStore.getName(), is(name));
+    assertThat(primaryMetaStore.getRemoteMetaStoreUris(), is(remoteMetaStoreUri));
+    assertThat(primaryMetaStore.getDatabasePrefix(), is(databasePrefix));
+    assertThat(primaryMetaStore.getAccessControlType(), is(access));
+  }
+
+
+  @Test
   public void mappedDatabases() {
     List<String> mappedDatabases = new ArrayList<>();
     mappedDatabases.add("database");

--- a/waggle-dance-api/src/test/java/com/hotels/bdp/waggledance/api/model/PrimaryMetaStoreTest.java
+++ b/waggle-dance-api/src/test/java/com/hotels/bdp/waggledance/api/model/PrimaryMetaStoreTest.java
@@ -36,6 +36,7 @@ public class PrimaryMetaStoreTest extends AbstractMetaStoreTest<PrimaryMetaStore
   private final String remoteMetaStoreUris = "remoteMetaStoreUris";
   private final List<String> whitelist = new ArrayList<>();
   private final AccessControlType accessControlType = AccessControlType.READ_AND_WRITE_ON_DATABASE_WHITELIST;
+  private final String databasePrefix = "primary";
 
   public PrimaryMetaStoreTest() {
     super(new PrimaryMetaStore());
@@ -116,6 +117,31 @@ public class PrimaryMetaStoreTest extends AbstractMetaStoreTest<PrimaryMetaStore
     PrimaryMetaStore store = new PrimaryMetaStore(name, remoteMetaStoreUris, accessControlType, whitelist);
     assertThat(store.getName(), is(name));
     assertThat(store.getRemoteMetaStoreUris(), is(remoteMetaStoreUris));
+    assertThat(store.getAccessControlType(), is(accessControlType));
+    assertThat(store.getWritableDatabaseWhiteList(), is(whitelist));
+  }
+
+  @Test
+  public void nonEmptyPrefixConstructor() {
+    whitelist.add("databaseOne");
+    whitelist.add("databaseTwo");
+    PrimaryMetaStore store = new PrimaryMetaStore(name, remoteMetaStoreUris, databasePrefix, accessControlType, whitelist.get(0),
+            whitelist.get(1));
+    assertThat(store.getName(), is(name));
+    assertThat(store.getRemoteMetaStoreUris(), is(remoteMetaStoreUris));
+    assertThat(store.getDatabasePrefix(), is(databasePrefix));
+    assertThat(store.getAccessControlType(), is(accessControlType));
+    assertThat(store.getWritableDatabaseWhiteList(), is(whitelist));
+  }
+
+  @Test
+  public void constructorWithPrefixArrayListForWhitelist() {
+    whitelist.add("databaseOne");
+    whitelist.add("databaseTwo");
+    PrimaryMetaStore store = new PrimaryMetaStore(name, remoteMetaStoreUris, databasePrefix, accessControlType, whitelist);
+    assertThat(store.getName(), is(name));
+    assertThat(store.getRemoteMetaStoreUris(), is(remoteMetaStoreUris));
+    assertThat(store.getDatabasePrefix(), is(databasePrefix));
     assertThat(store.getAccessControlType(), is(accessControlType));
     assertThat(store.getWritableDatabaseWhiteList(), is(whitelist));
   }

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/server/security/DatabaseWhitelistAccessControlHandler.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/server/security/DatabaseWhitelistAccessControlHandler.java
@@ -74,7 +74,7 @@ public class DatabaseWhitelistAccessControlHandler implements AccessControlHandl
     AbstractMetaStore newMetaStore;
     if (metaStore instanceof PrimaryMetaStore) {
       newMetaStore = new PrimaryMetaStore(metaStore.getName(), metaStore.getRemoteMetaStoreUris(),
-          metaStore.getAccessControlType(), newWritableDatabaseWhiteList);
+          metaStore.getDatabasePrefix(), metaStore.getAccessControlType(), newWritableDatabaseWhiteList);
       newMetaStore.setMappedDatabases(mappedDatabases);
     } else {
       throw new WaggleDanceException(

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/server/security/ReadWriteCreateAccessControlHandler.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/server/security/ReadWriteCreateAccessControlHandler.java
@@ -55,7 +55,7 @@ public class ReadWriteCreateAccessControlHandler implements AccessControlHandler
     AbstractMetaStore newMetaStore;
     if (metaStore instanceof PrimaryMetaStore) {
       newMetaStore = new PrimaryMetaStore(metaStore.getName(), metaStore.getRemoteMetaStoreUris(),
-          metaStore.getAccessControlType());
+          metaStore.getDatabasePrefix(), metaStore.getAccessControlType());
       newMetaStore.setMappedDatabases(mappedDatabases);
     } else {
       throw new WaggleDanceException(


### PR DESCRIPTION
…e primary cluster created the database.

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
  https://github.com/HotelsDotCom/waggle-dance/blob/main/CONTRIBUTING.md
-->

### :pencil:
Configure the primary-meta-store.database-prefix: usercluster2_ for the primary database. Connect to waggle-dance through hs2 and execute create database xxx. The primary database prefix is ​​lost when showing databases.

<img width="726" alt="Clipboard_Screenshot_1739179415" src="https://github.com/user-attachments/assets/f3f8887f-71c8-45c7-81bf-f84fbdf49cea" />



### :link: Related Issues