### PR TITLE
fix pattern

### DIFF
--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/mapping/service/GrammarUtils.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/mapping/service/GrammarUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2021 Expedia, Inc.
+ * Copyright (C) 2016-2025 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,8 @@
  */
 package com.hotels.bdp.waggledance.mapping.service;
 
-import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -97,19 +97,20 @@ public final class GrammarUtils {
       return matchingPrefixes;
     }
 
-    Map<String, List<String>> prefixPatterns = new HashMap<>();
+    Map<String, Set<String>> prefixPatterns = new HashMap<>();
     for (String subPattern : OR_SPLITTER.split(dbPatterns)) {
       for (String prefix : prefixes) {
-        String[] subPatternParts = splitPattern(prefix, subPattern);
-        if (subPatternParts.length == 0) {
+        HivePrefixPattern hivePrefixPattern = new HivePrefixPattern(prefix, subPattern);
+        List<String> subPatterns = hivePrefixPattern.getSubPatterns();
+        if (subPatterns.isEmpty()) {
           continue;
         }
-        List<String> prefixPatternList = prefixPatterns.computeIfAbsent(prefix, k -> new ArrayList<>());
-        prefixPatternList.add(subPatternParts[1]);
+        Set<String> prefixPatternList = prefixPatterns.computeIfAbsent(prefix, k -> new HashSet<>());
+        prefixPatternList.addAll(hivePrefixPattern.getSubPatterns());
       }
     }
 
-    for (Entry<String, List<String>> prefixPatternEntry : prefixPatterns.entrySet()) {
+    for (Entry<String, Set<String>> prefixPatternEntry : prefixPatterns.entrySet()) {
       matchingPrefixes.put(prefixPatternEntry.getKey(), OR_JOINER.join(prefixPatternEntry.getValue()));
     }
     return matchingPrefixes;

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/mapping/service/GrammarUtils.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/mapping/service/GrammarUtils.java
@@ -64,8 +64,8 @@ public final class GrammarUtils {
         if (subPatterns.isEmpty()) {
           continue;
         }
-        Set<String> prefixPatternList = prefixPatterns.computeIfAbsent(prefix, k -> new HashSet<>());
-        prefixPatternList.addAll(hivePrefixPattern.getSubPatterns());
+        Set<String> prefixPatternSet = prefixPatterns.computeIfAbsent(prefix, k -> new HashSet<>());
+        prefixPatternSet.addAll(hivePrefixPattern.getSubPatterns());
       }
     }
 

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/mapping/service/GrammarUtils.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/mapping/service/GrammarUtils.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 
@@ -33,46 +32,6 @@ public final class GrammarUtils {
   private static final Joiner OR_JOINER = Joiner.on(OR_SEPARATOR);
 
   private GrammarUtils() {}
-
-  @VisibleForTesting
-  static String[] splitPattern(String prefix, String pattern) {
-    if (pattern.startsWith(prefix)) {
-      return new String[] { prefix, pattern.substring(prefix.length()) };
-    }
-
-    // Find the longest sub-pattern that matches the prefix
-    String subPattern = pattern;
-    int index = pattern.length();
-    while (index >= 0) {
-      String subPatternRegex = subPattern.replaceAll("\\*", ".*");
-      if (prefix.matches(subPatternRegex)) {
-        if (subPattern.endsWith("*")) {
-          // * is a multi character match so belongs to prefix and pattern.
-          return new String[] { subPattern, pattern.substring(subPattern.length() - 1) };
-        }
-        // Dot is a one character x match so can't belong to the pattern anymore.
-        return new String[] { subPattern, pattern.substring(subPattern.length()) };
-      }
-      // Skip last * or . and find the next sub-pattern
-      if (subPattern.endsWith("*") || subPattern.endsWith(".")) {
-        subPattern = subPattern.substring(0, subPattern.length() - 1);
-      }
-      int lastStar = subPattern.lastIndexOf('*');
-      int lastDot = subPattern.lastIndexOf('.');
-      if (lastStar > lastDot) {
-        index = lastStar;
-        if (lastStar >= 0) {
-          subPattern = subPattern.substring(0, index + 1);
-        }
-      } else {
-        index = lastDot;
-        if (lastDot >= 0) {
-          subPattern = subPattern.substring(0, subPattern.length() - 1);
-        }
-      }
-    }
-    return new String[] {};
-  }
 
   /**
    * Selects Waggle Dance database mappings that can potentially match the provided pattern.

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/mapping/service/HivePrefixPattern.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/mapping/service/HivePrefixPattern.java
@@ -21,9 +21,9 @@ import java.util.List;
 import com.google.common.annotations.VisibleForTesting;
 
 public class HivePrefixPattern {
-  private final String prefix;
+  private String prefix;
   private String pattern;
-  private final List<String> subPatterns;
+  private final List<String> subPatterns = new ArrayList<>();
 
   /**
    * Using a dynamic programming algorithm to match a given pattern with an input string,
@@ -71,16 +71,15 @@ public class HivePrefixPattern {
   }
 
   public HivePrefixPattern(String prefix, String pattern) {
+    if (prefix == null || pattern == null) {
+      return;
+    }
     this.prefix = prefix;
     this.pattern = pattern;
-    this.subPatterns = new ArrayList<>();
     init();
   }
 
   private void init() {
-    if (this.prefix == null || this.pattern == null) {
-      return;
-    }
     boolean[] match = matchDp(this.prefix, this.pattern);
     if (match[0]) {
       this.subPatterns.add(this.pattern);

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/mapping/service/HivePrefixPattern.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/mapping/service/HivePrefixPattern.java
@@ -25,35 +25,48 @@ public class HivePrefixPattern {
   private String pattern;
   private final List<String> subPatterns;
 
+  /**
+   * Using a dynamic programming algorithm to match a given pattern with an input string,
+   * where '*' represents matching any number of any characters,
+   * and '.' represents matching a single arbitrary character.
+   *
+   * @param input input string.
+   * @param pattern regular expression.
+   * @return A boolean array with a length of one more than the length of the pattern.
+   * If the substring of the pattern from index 0 to i+1 can match the input string,
+   * the value at index i of the boolean array is true; otherwise, it is false.
+   */
   @VisibleForTesting
   static boolean[] matchDp(String input, String pattern) {
     int m = input.length() + 1;
     int n = pattern.length() + 1;
-    boolean[] dp = new boolean[n];
-    boolean[] prev = new boolean[n];
+    boolean[] matchingResult = new boolean[n];
+    boolean[] prevMatchingResult = new boolean[n];
 
-    dp[0] = true;
+    matchingResult[0] = true;
 
     for (int j = 1; j < n; j++) {
-      dp[j] = dp[j - 1] && pattern.charAt(j - 1) == '*';
+      matchingResult[j] = matchingResult[j - 1] && pattern.charAt(j - 1) == '*';
     }
 
     for (int i = 1; i < m; i++) {
-      copy(prev, dp);
-      dp[0] = false;
+      copy(prevMatchingResult, matchingResult);
+      matchingResult[0] = false;
       for (int j = 1; j < n; j++) {
-        dp[j] = pattern.charAt(j - 1) == '*' ?
-            prev[j] || prev[j - 1] || dp[j - 1] :
-            prev[j - 1] && (pattern.charAt(j - 1) == '.'
-                || input.charAt(i - 1) == pattern.charAt(j - 1));
+        if (pattern.charAt(j - 1) == '*') {
+          matchingResult[j] = prevMatchingResult[j] || prevMatchingResult[j - 1] || matchingResult[j - 1];
+        } else {
+          matchingResult[j] = prevMatchingResult[j - 1] && (pattern.charAt(j - 1) == '.'
+              || input.charAt(i - 1) == pattern.charAt(j - 1));
+        }
       }
     }
-    return dp;
+    return matchingResult;
   }
 
-  static void copy(boolean[] prev, boolean[] dp) {
+  static void copy(boolean[] prev, boolean[] current) {
     for (int i = 0; i < prev.length; i++) {
-      prev[i] = dp[i];
+      prev[i] = current[i];
     }
   }
 

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/mapping/service/HivePrefixPattern.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/mapping/service/HivePrefixPattern.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (C) 2016-2025 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hotels.bdp.waggledance.mapping.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.common.annotations.VisibleForTesting;
+
+public class HivePrefixPattern {
+  private final String prefix;
+  private String pattern;
+  private final List<String> subPatterns;
+
+  @VisibleForTesting
+  static boolean[] matchDp(String input, String pattern) {
+    int m = input.length() + 1;
+    int n = pattern.length() + 1;
+    boolean[] dp = new boolean[n];
+    boolean[] prev = new boolean[n];
+
+    dp[0] = true;
+
+    for (int j = 1; j < n; j++) {
+      dp[j] = dp[j - 1] && pattern.charAt(j - 1) == '*';
+    }
+
+    for (int i = 1; i < m; i++) {
+      copy(prev, dp);
+      dp[0] = false;
+      for (int j = 1; j < n; j++) {
+        dp[j] = pattern.charAt(j - 1) == '*' ?
+            prev[j] || prev[j - 1] || dp[j - 1] :
+            prev[j - 1] && (pattern.charAt(j - 1) == '.'
+                || input.charAt(i - 1) == pattern.charAt(j - 1));
+      }
+    }
+    return dp;
+  }
+
+  static void copy(boolean[] prev, boolean[] dp) {
+    for (int i = 0; i < prev.length; i++) {
+      prev[i] = dp[i];
+    }
+  }
+
+  public HivePrefixPattern(String prefix, String pattern) {
+    this.prefix = prefix;
+    this.pattern = pattern;
+    this.subPatterns = new ArrayList<>();
+    init();
+  }
+
+  private void init() {
+    if (this.prefix == null || this.pattern == null) {
+      return;
+    }
+    boolean[] match = matchDp(this.prefix, this.pattern);
+    if (match[0]) {
+      this.subPatterns.add(this.pattern);
+    }
+    int n = this.pattern.length();
+    for (int j = 1; j <= n; j++) {
+      if (!match[j]) {
+        continue;
+      }
+      String subPattern = this.pattern.charAt(j - 1) == '*' ?
+          this.pattern.substring(j - 1, n) : this.pattern.substring(j, n);
+      if (subPattern.isEmpty()) {
+        continue;
+      }
+      this.subPatterns.add(subPattern);
+    }
+  }
+
+  public String getPrefix() {
+    return prefix;
+  }
+
+  public String getPattern() {
+    return pattern;
+  }
+
+  public List<String> getSubPatterns() {
+    return subPatterns;
+  }
+
+  @Override
+  public String toString() {
+    return "HivePrefixPattern{" +
+        "prefix='" + prefix + '\'' +
+        ", pattern='" + pattern + '\'' +
+        ", subPatterns=" + subPatterns +
+        '}';
+  }
+}

--- a/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/service/GrammarUtilsTest.java
+++ b/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/service/GrammarUtilsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2021 Expedia, Inc.
+ * Copyright (C) 2016-2025 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -133,6 +133,10 @@ public class GrammarUtilsTest {
     Map<String, String> splits = GrammarUtils.selectMatchingPrefixes(ImmutableSet.of(PREFIX, "other_"), "other.dm");
     assertThat(splits.size(), is(1));
     assertThat(splits.get("other_"), is("dm"));
+
+    splits = GrammarUtils.selectMatchingPrefixes(ImmutableSet.of(PREFIX), "waggle*.dm");
+    assertThat(splits.size(), is(1));
+    assertThat(splits.get(PREFIX), is("dm|*.dm"));
   }
 
   @Test
@@ -177,7 +181,7 @@ public class GrammarUtilsTest {
         .selectMatchingPrefixes(ImmutableSet.of(PREFIX, "other_"), "w*base|oth*_*dat");
     assertThat(splits.size(), is(2));
     assertThat(splits.get(PREFIX), is("*base"));
-    assertThat(splits.get("other_"), is("*dat"));
+    assertThat(splits.get("other_"), is("*_*dat|*dat"));
   }
 
   @Test
@@ -186,15 +190,21 @@ public class GrammarUtilsTest {
         .selectMatchingPrefixes(ImmutableSet.of(PREFIX, "wother_"), "w*base|woth*_*dat");
     assertThat(splits.size(), is(2));
     assertThat(splits.get(PREFIX), is("*base"));
-    assertThat(splits.get("wother_"), is("*base|*dat"));
+    assertThat(splits.get("wother_"), is("*base|*_*dat|*dat"));
   }
 
   @Test
   public void multipleMatchesPatternWithMultipleWildcard() {
     Map<String, String> splits = GrammarUtils.selectMatchingPrefixes(ImmutableSet.of(PREFIX, "baggle_"), "*aggle*");
     assertThat(splits.size(), is(2));
-    assertThat(splits.get(PREFIX), is("*"));
-    assertThat(splits.get("baggle_"), is("*"));
+    assertThat(splits.get(PREFIX), is("*|*aggle*"));
+    assertThat(splits.get("baggle_"), is("*|*aggle*"));
   }
 
+  @Test
+  public void matchesPatternWithFullPrefix() {
+    Map<String, String> splits = GrammarUtils.selectMatchingPrefixes(
+        ImmutableSet.of(PREFIX, "baggle_"), PREFIX + "|" + "baggle_");
+    assertThat(splits.size(), is(0));
+  }
 }

--- a/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/service/GrammarUtilsTest.java
+++ b/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/service/GrammarUtilsTest.java
@@ -20,8 +20,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertNull;
 
 import java.util.Map;
-
-import org.hamcrest.collection.IsArrayWithSize;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableSet;
@@ -29,88 +27,6 @@ import com.google.common.collect.ImmutableSet;
 public class GrammarUtilsTest {
 
   private static final String PREFIX = "waggle_";
-
-  @Test
-  public void emptySubPattern() {
-    String[] patternParts = GrammarUtils.splitPattern(PREFIX, "");
-    assertThat(patternParts, IsArrayWithSize.emptyArray());
-  }
-
-  @Test
-  public void basicSubPatternMatchingPrefix() {
-    String[] patternParts = GrammarUtils.splitPattern(PREFIX, "waggle_");
-    assertThat(patternParts[0], is(PREFIX));
-    assertThat(patternParts[1], is(""));
-  }
-
-  @Test
-  public void basicSubPatternNotMatchingPrefix() {
-    String[] patternParts = GrammarUtils.splitPattern("prefix", "waggle_");
-    assertThat(patternParts, IsArrayWithSize.emptyArray());
-  }
-
-  @Test
-  public void subPatternMatchesEverything() {
-    String[] patternParts = GrammarUtils.splitPattern(PREFIX, "*");
-    assertThat(patternParts[0], is("*"));
-    assertThat(patternParts[1], is("*"));
-  }
-
-  @Test
-  public void subPatternMatchesAllTables() {
-    String[] patternParts = GrammarUtils.splitPattern(PREFIX, "waggle_*");
-    assertThat(patternParts[0], is(PREFIX));
-    assertThat(patternParts[1], is("*"));
-  }
-
-  @Test
-  public void subPatternMatchesAllSpecificTables() {
-    String[] patternParts = GrammarUtils.splitPattern(PREFIX, "waggle_*base");
-    assertThat(patternParts[0], is(PREFIX));
-    assertThat(patternParts[1], is("*base"));
-  }
-
-  @Test
-  public void subPatternMatchesDatabaseAndAllSpecificTables() {
-    String[] patternParts = GrammarUtils.splitPattern(PREFIX, "wag*base");
-    assertThat(patternParts[0], is("wag*"));
-    assertThat(patternParts[1], is("*base"));
-  }
-
-  @Test
-  public void splitPatternWithDot() {
-    String[] patternParts = GrammarUtils.splitPattern(PREFIX, "waggle.dm*");
-    assertThat(patternParts[0], is("waggle."));
-    assertThat(patternParts[1], is("dm*"));
-  }
-
-  @Test
-  public void splitPatternWithDots() {
-    String[] patternParts = GrammarUtils.splitPattern(PREFIX, "waggle...dm");
-    assertThat(patternParts[0], is("waggle."));
-    assertThat(patternParts[1], is("..dm"));
-  }
-
-  @Test
-  public void splitPatternWithDotsAndStarEnd() {
-    String[] patternParts = GrammarUtils.splitPattern(PREFIX, "waggle...dm*");
-    assertThat(patternParts[0], is("waggle."));
-    assertThat(patternParts[1], is("..dm*"));
-  }
-
-  @Test
-  public void splitPatternWithDotsAndStar() {
-    String[] patternParts = GrammarUtils.splitPattern(PREFIX, "waggle.*.dm");
-    assertThat(patternParts[0], is("waggle.*"));
-    assertThat(patternParts[1], is("*.dm"));
-  }
-
-  @Test
-  public void splitPatternWithDotsInMiddle() {
-    String[] patternParts = GrammarUtils.splitPattern(PREFIX, "wa..le_dm");
-    assertThat(patternParts[0], is("wa..le_"));
-    assertThat(patternParts[1], is("dm"));
-  }
 
   @Test
   public void matchesWithNullPattern() {

--- a/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/service/GrammarUtilsTest.java
+++ b/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/service/GrammarUtilsTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertNull;
 
 import java.util.Map;
+
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableSet;

--- a/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/service/HivePrefixPatternTest.java
+++ b/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/service/HivePrefixPatternTest.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright (C) 2016-2025 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hotels.bdp.waggledance.mapping.service;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+public class HivePrefixPatternTest {
+  private static final String PREFIX = "waggle_";
+
+  @Test
+  public void hivePrefixPatternMatchDp() {
+    boolean[] matched = HivePrefixPattern.matchDp(PREFIX, "wa...*sgdyu");
+    checkMatched(matched, false, false, false, false, false, false,
+        true, false, false, false, false, false);
+
+    matched = HivePrefixPattern.matchDp(PREFIX, "wa.....sgdyu");
+    checkMatched(matched, false, false, false, false, false, false,
+        false, true, false, false, false, false, false);
+
+    matched = HivePrefixPattern.matchDp(PREFIX, "wa.**.sgdyu");
+    checkMatched(matched, false, false, false, false, true,
+        true, true, false, false, false, false, false);
+
+    matched = HivePrefixPattern.matchDp(PREFIX, "wa.**....sgdyu");
+    checkMatched(matched, false, false, false, false, true, true,
+        true, true, true, true, false, false, false, false, false);
+
+    matched = HivePrefixPattern.matchDp("", "wa.**....sgdyu");
+    checkMatched(matched, true, false, false, false, false, false,
+        false, false, false, false, false, false, false, false, false);
+
+    matched = HivePrefixPattern.matchDp("", "*wa.**....sgdyu");
+    checkMatched(matched, true, true, false, false, false, false, false,
+        false, false, false, false, false, false, false, false, false);
+  }
+
+  @Test
+  public void hivePrefixPattern() {
+    HivePrefixPattern hivePrefixPattern = new HivePrefixPattern(PREFIX, "wa...*sgdyu");
+    assertEquals(Arrays.asList("*sgdyu"), hivePrefixPattern.getSubPatterns());
+
+    hivePrefixPattern = new HivePrefixPattern(PREFIX, "wa.....sgdyu");
+    assertEquals(Arrays.asList("sgdyu"), hivePrefixPattern.getSubPatterns());
+
+    hivePrefixPattern = new HivePrefixPattern(PREFIX, "wa.**.sgdyu");
+    assertEquals(Arrays.asList("**.sgdyu", "*.sgdyu", "sgdyu"), hivePrefixPattern.getSubPatterns());
+
+    hivePrefixPattern = new HivePrefixPattern(PREFIX, "wa.**....sgdyu");
+    assertEquals(Arrays.asList("**....sgdyu", "*....sgdyu", "...sgdyu", "..sgdyu", ".sgdyu", "sgdyu"),
+        hivePrefixPattern.getSubPatterns());
+
+
+    hivePrefixPattern = new HivePrefixPattern("", "wa.**....sgdyu");
+    assertEquals(Arrays.asList("wa.**....sgdyu"),
+        hivePrefixPattern.getSubPatterns());
+
+    hivePrefixPattern = new HivePrefixPattern("", "*wa.**....sgdyu");
+    assertEquals(Arrays.asList("*wa.**....sgdyu", "*wa.**....sgdyu"),
+        hivePrefixPattern.getSubPatterns());
+
+    hivePrefixPattern = new HivePrefixPattern(PREFIX, "*waggle_*...sgdyu");
+    assertEquals(Arrays.asList("*waggle_*...sgdyu", "*...sgdyu", "*...sgdyu"),
+        hivePrefixPattern.getSubPatterns());
+
+    hivePrefixPattern = new HivePrefixPattern(PREFIX, "waggl*...sgdyu");
+    assertEquals(Arrays.asList("*...sgdyu", "..sgdyu", ".sgdyu"),
+        hivePrefixPattern.getSubPatterns());
+
+    hivePrefixPattern = new HivePrefixPattern(PREFIX, "wag*..*...sgdyu");
+    assertEquals(Arrays.asList("*..*...sgdyu", ".*...sgdyu", "*...sgdyu", "*...sgdyu", "..sgdyu", ".sgdyu"),
+        hivePrefixPattern.getSubPatterns());
+
+    hivePrefixPattern = new HivePrefixPattern(PREFIX, "waggle_sgdyu");
+    assertEquals(Arrays.asList("sgdyu"),
+        hivePrefixPattern.getSubPatterns());
+  }
+
+  private void checkMatched(boolean[] matched, boolean... expected) {
+    for (int i = 0; i < matched.length; i++) {
+      assertEquals(expected[i], matched[i]);
+    }
+  }
+}

--- a/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/service/impl/PrefixBasedDatabaseMappingServiceTest.java
+++ b/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/service/impl/PrefixBasedDatabaseMappingServiceTest.java
@@ -414,7 +414,7 @@ public class PrefixBasedDatabaseMappingServiceTest {
     when(metaStoreMappingFederated.getClient()).thenReturn(federatedDatabaseClient);
     when(metaStoreMappingFederated.transformOutboundDatabaseNameMultiple(FEDERATED_DB))
         .thenReturn(Lists.newArrayList(FEDERATED_DB));
-    when(federatedDatabaseClient.get_databases(pattern)).thenReturn(Lists.newArrayList(FEDERATED_DB));
+    when(federatedDatabaseClient.get_databases("*_db|db")).thenReturn(Lists.newArrayList(FEDERATED_DB));
 
     PanopticOperationHandler handler = service.getPanopticOperationHandler();
     List<String> allDatabases = handler.getAllDatabases(pattern);
@@ -436,7 +436,7 @@ public class PrefixBasedDatabaseMappingServiceTest {
         .thenReturn(Lists.newArrayList(FEDERATED_DB));
     when(primaryDatabaseClient.get_databases(pattern))
         .thenReturn(Lists.newArrayList(PRIMARY_DB, "primary_db_that_is_not_mapped_and_ends_with_db"));
-    when(federatedDatabaseClient.get_databases(pattern))
+    when(federatedDatabaseClient.get_databases("*_db|db"))
         .thenReturn(Lists.newArrayList(FEDERATED_DB, "another_db_that_is_not_mapped_and_ends_with_db"));
 
     PanopticOperationHandler handler = service.getPanopticOperationHandler();
@@ -471,7 +471,7 @@ public class PrefixBasedDatabaseMappingServiceTest {
     when(primaryDatabaseClient.get_table_meta("*_db", "*", null))
         .thenReturn(Collections.singletonList(primaryTableMeta));
     when(metaStoreMappingFederated.getClient()).thenReturn(federatedDatabaseClient);
-    when(federatedDatabaseClient.get_table_meta("*_db", "*", null))
+    when(federatedDatabaseClient.get_table_meta("*_db|db", "*", null))
         .thenReturn(Collections.singletonList(federatedTableMeta));
     when(metaStoreMappingFederated.transformOutboundDatabaseName(FEDERATED_DB)).thenReturn("name_federated_db");
 
@@ -496,7 +496,7 @@ public class PrefixBasedDatabaseMappingServiceTest {
     when(primaryDatabaseClient.get_table_meta("*_db", "*", null))
         .thenReturn(Collections.singletonList(primaryTableMeta));
     when(metaStoreMappingFederated.getClient()).thenReturn(federatedDatabaseClient);
-    when(federatedDatabaseClient.get_table_meta("*_db", "*", null))
+    when(federatedDatabaseClient.get_table_meta("*_db|db", "*", null))
         .thenReturn(Collections.singletonList(federatedTableMeta));
     when(metaStoreMappingFederated.transformOutboundDatabaseName(FEDERATED_DB)).thenReturn("name_federated_db");
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
  https://github.com/HotelsDotCom/waggle-dance/blob/main/CONTRIBUTING.md
-->

### :pencil: Description
Currently, it has been found that using prefix matching can lead to incorrect results. Here is a case: 
 The prefix is `waggle_`, and the matching pattern is `waggle*..dm`. In this case, it will go to the Hive Metastore corresponding to `waggle_` and obtain the database through the pattern `dm`. However, this only retrieves the database named `waggle_dm`. If I have a database named `waggle_abdm`, `waggle_abcdm`, or `waggle_aaaaaaabcdm`, these should still be matched by `waggle*..dm`.
![image](https://github.com/user-attachments/assets/9a601501-c951-4da0-b2f1-0dbcd2ba0065)

### :link: Related Issues