### PR TITLE
fix: does not replace function name without db name.

### DIFF
--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/mapping/model/ASTQueryMapping.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/mapping/model/ASTQueryMapping.java
@@ -93,6 +93,10 @@ public enum ASTQueryMapping implements QueryMapping {
     List<CommonToken> functionTokens = extractFunctionTokens(root);
     for (CommonToken functionNode : functionTokens) {
       final String functionName = functionNode.getText();
+      // No dbname, no need to replace.
+      if (!functionName.contains(".")) {
+        continue;
+      }
       Pattern pattern = Pattern.compile(RE_WORD_BOUNDARY + functionName + RE_WORD_BOUNDARY);
       Matcher matcher = pattern.matcher(result);
       if (matcher.find()) {

--- a/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/model/ASTQueryMappingTest.java
+++ b/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/model/ASTQueryMappingTest.java
@@ -115,6 +115,28 @@ public class ASTQueryMappingTest {
   }
 
   @Test
+  public void transformOutboundDatabaseNameOnFunctionNoDbName() {
+    ASTQueryMapping queryMapping = ASTQueryMapping.INSTANCE;
+
+    String query = "CREATE VIEW test_view AS SELECT a.c1 FROM (SELECT fun(),1) a";
+    assertThat(queryMapping.transformOutboundDatabaseName(metaStoreMapping, query),
+        is("CREATE VIEW test_view AS SELECT a.c1 FROM (SELECT fun(),1) a"));
+
+    query = "CREATE VIEW db1.test_view AS SELECT a.c1 FROM (SELECT fun(), db.fun2()) a";
+    assertThat(queryMapping.transformOutboundDatabaseName(metaStoreMapping, query),
+        is("CREATE VIEW " + PREFIX + "db1.test_view AS SELECT a.c1 FROM " +
+                    "(SELECT fun(), " + PREFIX +"db.fun2()) a"));
+
+    query = "SELECT hellobdp() as q union all SELECT hellobdp() as qq where false";
+    assertThat(queryMapping.transformOutboundDatabaseName(metaStoreMapping, query),
+        is("SELECT hellobdp() as q union all SELECT hellobdp() as qq where false"));
+
+    query = "SELECT hellobdp() as q union all SELECT db1.hellobdp() as qq where false";
+    assertThat(queryMapping.transformOutboundDatabaseName(metaStoreMapping, query),
+        is("SELECT hellobdp() as q union all SELECT " + PREFIX + "db1.hellobdp() as qq where false"));
+  }
+
+  @Test
   public void transformOutboundDatabaseNameOnMultipleSameFunctions() {
     ASTQueryMapping queryMapping = ASTQueryMapping.INSTANCE;
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
  https://github.com/HotelsDotCom/waggle-dance/blob/main/CONTRIBUTING.md
-->

### :pencil: Description
When a function does not have database information, there is no need to add a prefix to the function. Otherwise, it may result in a function named fun() being incorrectly modified to prefix_fun().

### :link: Related Issues