### PR TITLE
fix: Function names with parameters cannot have a prefix.

### DIFF
--- a/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/model/ASTQueryMappingTest.java
+++ b/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/model/ASTQueryMappingTest.java
@@ -134,6 +134,14 @@ public class ASTQueryMappingTest {
     query = "SELECT hellobdp() as q union all SELECT db1.hellobdp() as qq where false";
     assertThat(queryMapping.transformOutboundDatabaseName(metaStoreMapping, query),
         is("SELECT hellobdp() as q union all SELECT " + PREFIX + "db1.hellobdp() as qq where false"));
+
+    query = "SELECT COALESCE(db1.hellobdp(`table1.id`, 1)) where false";
+    assertThat(queryMapping.transformOutboundDatabaseName(metaStoreMapping, query),
+        is("SELECT COALESCE(" + PREFIX + "db1.hellobdp(`table1.id`, 1)) where false"));
+
+    query = "SELECT COALESCE(db1.hellobdp(`db2.fun2`(`table1.id`), 1)) where false";
+    assertThat(queryMapping.transformOutboundDatabaseName(metaStoreMapping, query),
+        is("SELECT COALESCE(" + PREFIX + "db1.hellobdp(`" + PREFIX + "db2.fun2`(`table1.id`), 1)) where false"));
   }
 
   @Test


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
  https://github.com/HotelsDotCom/waggle-dance/blob/main/CONTRIBUTING.md
-->

### :pencil: Description
When a function has parameters, using prefix routing can prevent these functions from being prefixed, resulting in them not being found.

You can use the original code to run the newly added unit tests, and the bug can be reproduced.

### :link: Related Issues