### PR TITLE
Report success when expected exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+## [4.0.2] - TBD
+### Fix
+- Fixed metric reporting failed calls on expected exceptions.
+
 ## [4.0.1] - 2025-06-27
 ### Fix
 - Fixed issue where a call to an unavailable metastore got redirected to "primary" which results in NoSuchObjectException instead of TException causing clients to not retry. 

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/metrics/MonitoredAspect.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/metrics/MonitoredAspect.java
@@ -20,6 +20,8 @@ import static com.hotels.bdp.waggledance.metrics.CurrentMonitoredMetaStoreHolder
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.hadoop.hive.metastore.api.AlreadyExistsException;
+import org.apache.hadoop.hive.metastore.api.InvalidObjectException;
 import org.apache.hadoop.hive.metastore.api.InvalidOperationException;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
 import org.aspectj.lang.ProceedingJoinPoint;
@@ -64,10 +66,10 @@ public class MonitoredAspect {
       Object returnObj = pjp.proceed();
       result = "success";
       return returnObj;
-    } catch (NoSuchObjectException | InvalidOperationException t) {
+    } catch (NoSuchObjectException | InvalidOperationException | InvalidObjectException | AlreadyExistsException e) {
       //expected Exception e.g. when getTable is called and the table does not exist.
       result = "success";
-      throw t;
+      throw e;
     } catch (Throwable t) {
       result = "failure";
       throw t;

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/metrics/MonitoredAspect.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/metrics/MonitoredAspect.java
@@ -20,6 +20,8 @@ import static com.hotels.bdp.waggledance.metrics.CurrentMonitoredMetaStoreHolder
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.hadoop.hive.metastore.api.InvalidOperationException;
+import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
@@ -62,6 +64,10 @@ public class MonitoredAspect {
       Object returnObj = pjp.proceed();
       result = "success";
       return returnObj;
+    } catch (NoSuchObjectException | InvalidOperationException t) {
+      //expected Exception e.g. when getTable is called and the table does not exist.
+      result = "success";
+      throw t;
     } catch (Throwable t) {
       result = "failure";
       throw t;

--- a/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/metrics/MonitoredAspectTest.java
+++ b/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/metrics/MonitoredAspectTest.java
@@ -22,8 +22,11 @@ import static org.mockito.Mockito.when;
 
 import java.util.Collection;
 
+import org.apache.hadoop.hive.metastore.api.AlreadyExistsException;
+import org.apache.hadoop.hive.metastore.api.InvalidObjectException;
 import org.apache.hadoop.hive.metastore.api.InvalidOperationException;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
+import org.apache.thrift.TException;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.Signature;
 import org.junit.Before;
@@ -102,30 +105,30 @@ public class MonitoredAspectTest {
   
   @Test
   public void monitorSuccessOnNoSuchObjectException() throws Throwable {
-    when(pjp.proceed()).thenThrow(new NoSuchObjectException());
-    try {
-      aspect.monitor(pjp, monitored);
-    } catch (NoSuchObjectException e) {
-      // Expected
-    }
-
-    RequiredSearch rs = meterRegistry.get("counter.Type_Anonymous.myMethod.all.calls");
-    assertThat(rs.counter().count(), is(1.0));
-
-    rs = meterRegistry.get("counter.Type_Anonymous.myMethod.all.success");
-    assertThat(rs.counter().count(), is(1.0));
-
-    rs = meterRegistry.get("timer.Type_Anonymous.myMethod.all.duration");
-    assertThat(rs.timer().count(), is(1L));
+    testOnExpectedException(new NoSuchObjectException());
   }
-  
-  
+
+  @Test
+  public void monitorSuccessOnInvalidObjectException() throws Throwable {
+    testOnExpectedException(new InvalidObjectException());
+  }
+
   @Test
   public void monitorSuccessOnInvalidOperationException() throws Throwable {
-    when(pjp.proceed()).thenThrow(new InvalidOperationException());
+    testOnExpectedException(new InvalidOperationException());
+  }
+
+  @Test
+  public void monitorSuccessOnAlreadyExistsException() throws Throwable {
+    testOnExpectedException(new AlreadyExistsException());
+  }
+  
+  private void testOnExpectedException(TException expectedException) throws Throwable {
+    when(pjp.proceed()).thenThrow(expectedException);
     try {
       aspect.monitor(pjp, monitored);
-    } catch (InvalidOperationException e) {
+    } catch (Exception e) {
+      assertThat(e, is(expectedException));
       // Expected
     }
 


### PR DESCRIPTION
Background:
 metrics report expected exceptions as NoSuchObject as a failure but this is incorrect as this the the expected response.